### PR TITLE
Fix for best action Choice

### DIFF
--- a/Arena.py
+++ b/Arena.py
@@ -55,7 +55,7 @@ class Arena():
             assert(self.display)
             print("Game over: Turn ", str(it), "Result ", str(self.game.getGameEnded(board, 1)))
             self.display(board)
-        return self.game.getGameEnded(board, 1)
+        return curPlayer*self.game.getGameEnded(board, curPlayer)
 
     def playGames(self, num, verbose=False):
         """

--- a/MCTS.py
+++ b/MCTS.py
@@ -35,7 +35,8 @@ class MCTS():
         counts = [self.Nsa[(s,a)] if (s,a) in self.Nsa else 0 for a in range(self.game.getActionSize())]
 
         if temp==0:
-            bestA = np.argmax(counts)
+            bestAs = np.array(np.argwhere(counts == np.max(counts))).flatten()
+            bestA = np.random.choice(bestAs)
             probs = [0]*len(counts)
             probs[bestA]=1
             return probs


### PR DESCRIPTION
Since counts is an integer, taking bestA = np.argmax(counts) always weights our action choice towards earlier entries (in the list of actions) in the case of tie. We should pick randomly from the actions with equal counts.